### PR TITLE
Add .rubocop.yml

### DIFF
--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -1,0 +1,32 @@
+AllCops:
+  DisplayCopNames: true
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Metrics/LineLength:
+  Max: 99
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -23,7 +23,7 @@ Style/Documentation:
   Enabled: false
 
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
+  Enabled: false
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
I've looked across some of our services and compiled some commonly used rules. The idea here is to have a unified config file that could be used in our ruby projects.

@vinted/backend 